### PR TITLE
script, readme: plugin_auth_mode: token

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 
 This plugin allows to update a Kubernetes deployment.
   - Cert based auth for tls
+  - token based auth
   - Insecure auth without tls
-
-This version deprecates token based auth
 
 ## Usage
 
@@ -22,11 +21,12 @@ pipeline:
       - docker_password
       - server_url_<cluster>
       - server_cert_<cluster>
-      - client_cert_<cluster>
-      - client_key_<cluster>
+      - client_cert_<cluster> / - server_token_<cluster>
+      - client_key_<cluster> / - server_token_<cluster>
       - ...
     user: <kubernetes-user with a cluster-rolebinding>
     cluster: <kubernetes-cluster>
+    auth_mode: [ token | client-cert ] // provide only if providing server_cert_<cluster>
     deployment: [<kubernetes-deployements, ...>]
     repo: <org/repo>
     container: [ <containers,...> ]
@@ -46,6 +46,9 @@ pipeline:
 ## Required secrets
 
   - server_url
+  - token:
+    - server_token
+      - `kubectl get secret [ your default secret name ] -o yaml | egrep 'token:' > server.token`
   - tls:
     - server_cert
       - `kubectl get secret [ your default secret name ] -o yaml | egrep 'ca.crt:' > ca.crt`

--- a/update.sh
+++ b/update.sh
@@ -18,14 +18,10 @@ if [ ! -z ${PLUGIN_CLUSTER} ]; then
   # create dynamic cert var names
   SERVER_URL_VAR=SERVER_URL_${CLUSTER}
   SERVER_CERT_VAR=SERVER_CERT_${CLUSTER}
-  CLIENT_CERT_VAR=CLIENT_CERT_${CLUSTER}
-  CLIENT_KEY_VAR=CLIENT_KEY_${CLUSTER}
 
   # expand the var contents
   SERVER_URL=${!SERVER_URL_VAR}
   SERVER_CERT=${!SERVER_CERT_VAR}
-  CLIENT_CERT=${!CLIENT_CERT_VAR}
-  CLIENT_KEY=${!CLIENT_KEY_VAR}
 
   if [[ -z "${SERVER_URL}" ]]; then
     echo "[ERROR] drone secret: ${SERVER_URL_VAR} not added!"
@@ -35,32 +31,59 @@ if [ ! -z ${PLUGIN_CLUSTER} ]; then
   if [[ ! -z "${SERVER_CERT}" ]]; then
     echo "[INFO] Using secure connection with tls-certificate."
     echo ${SERVER_CERT} | base64 -d > ca.crt
-    kubectl config set-cluster default --server=${SERVER_URL} --certificate-authority=ca.crt
+    kubectl config set-cluster ${CLUSTER} --server=${SERVER_URL} --certificate-authority=ca.crt
 
-    if [[ ! -z "${CLIENT_CERT}" ]] && [[ ! -z "${CLIENT_KEY}" ]]; then
-      echo "[INFO] Setting client credentials with signed-certificate and key."
-      echo ${CLIENT_CERT} | base64 -d > client.crt
-      echo ${CLIENT_KEY} | base64 -d > client.key
-      kubectl config set-credentials ${USER} --client-certificate=client.crt --client-key=client.key
-    else
-      echo "[ERROR] Required plugin parameters:"
-      echo " - client_cert"
-      echo " - client_key"
-      echo "are not provided"
-      exit 1
+    # vars based on auth_mode
+    if [ ! -z ${PLUGIN_AUTH_MODE} ]; then
+      if [[ "${PLUGIN_AUTH_MODE}" == "token" ]]; then
+        echo "[INFO] Using Server token to authorize"
+        SERVER_TOKEN_VAR=SERVER_TOKEN_${CLUSTER}
+        # expand
+        SERVER_TOKEN=${!SERVER_TOKEN_VAR}
+        if [[ ! -z "${SERVER_TOKEN}" ]]; then
+          kubectl config set-credentials ${USER} --token=${SERVER_TOKEN}
+        else
+          echo "[ERROR] Required plugin param - server_token - not provided."
+          exit 1
+        fi
+      elif [[ "${PLUGIN_AUTH_MODE}" == "client-cert" ]]; then
+        echo "[INFO] Using Client cert and Key to authorize"
+        CLIENT_CERT_VAR=CLIENT_CERT_${CLUSTER}
+        CLIENT_KEY_VAR=CLIENT_KEY_${CLUSTER}
+        # expand
+        CLIENT_CERT=${!CLIENT_CERT_VAR}
+        CLIENT_KEY=${!CLIENT_KEY_VAR}
+
+        if [[ ! -z "${CLIENT_CERT}" ]] && [[ ! -z "${CLIENT_KEY}" ]]; then
+          echo "[INFO] Setting client credentials with signed-certificate and key."
+          echo ${CLIENT_CERT} | base64 -d > client.crt
+          echo ${CLIENT_KEY} | base64 -d > client.key
+          kubectl config set-credentials ${USER} --client-certificate=client.crt --client-key=client.key
+        else
+          echo "[ERROR] Required plugin parameters:"
+          echo " - client_cert"
+          echo " - client_key"
+          echo "are not provided"
+          exit 1
+        fi
+      else
+        echo "[ERROR] Required plugin param - auth_mode - not provided"
+        echo "[INFO] Should be either [ token | client-cert ]"
+        exit 1
+      fi
     fi
   else
     echo "[WARNING] Required plugin parameter: ${SERVER_CERT_VAR} not added!"
     echo "[WARNING] Using insecure connection to cluster"
-    kubectl config set-cluster default --server=${SERVER_URL} --insecure-skip-tls-verify=true
+    kubectl config set-cluster ${CLUSTER} --server=${SERVER_URL} --insecure-skip-tls-verify=true
   fi
 else
   echo "[ERROR] Required pipeline parameter: cluster not provided"
   exit 1
 fi
 
-kubectl config set-context default --cluster=default --user=${USER}
-kubectl config use-context default
+kubectl config set-context ${CLUSTER} --cluster=${CLUSTER} --user=${USER}
+kubectl config use-context ${CLUSTER}
 
 # kubectl version
 IFS=',' read -r -a DEPLOYMENTS <<< "${PLUGIN_DEPLOYMENT}"


### PR DESCRIPTION
adds:
  - auth_mode: token | client_cert
  - `cluster: default` to` cluster: ${CLUSTER}`
  - code sanity and readme changes

example usage of token based auth: 
  - drone deploying falcon on gke: https://drone.razorpay.com/razorpay/falcon/60/4