### PR TITLE
[BAD-28] Fix multi container

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This plugin allows to update a Kubernetes deployment.
 
 ## Usage
 
-This pipeline will update the `my-deployment` deployment with the image tagged `DRONE_COMMIT_SHA:0:8`
+This pipeline will update the all containers of `[kubernetes-deployements, ...]` deployment
+with the image tagged `${DRONE_REPO_BRANCH}-${DRONE_COMMIT_SHA}`
 
 ```yaml
 pipeline:
@@ -29,7 +30,6 @@ pipeline:
     auth_mode: [ token | client-cert ] // provide only if providing server_cert_<cluster>
     deployment: [<kubernetes-deployements, ...>]
     repo: <org/repo>
-    container: [ <containers,...> ]
     namespace: <kubernetes-namespace>
     tag:
       - ${DRONE_REPO_BRANCH}-${DRONE_COMMIT_SHA}

--- a/update.sh
+++ b/update.sh
@@ -119,8 +119,7 @@ startDeployment(){
   local CONTAINER=$1
 
   kubectl -n ${NAMESPACE} set image deployment/${DEPLOY} \
-    ${CONTAINER}="${PLUGIN_REPO}:${PLUGIN_TAG}" --record
-
+    *="${PLUGIN_REPO}:${PLUGIN_TAG}" --record
   pollDeploymentRollout ${NAMESPACE} ${DEPLOY}
   if [ "$?" -eq 0 ]; then
     return 0
@@ -138,14 +137,12 @@ startDeployments(){
 
   for DEPLOY in ${DEPLOYMENTS[@]}; do
     echo "[INFO] Deploying ${DEPLOY} to ${CLUSTER} ${NAMESPACE}"
-    for CONTAINER in ${CONTAINERS[@]}; do
-      startDeployment ${NAMESPACE} ${DEPLOY} ${CONTAINER}
-      if [ "$?" -eq 0 ]; then
-        continue
-      else
-        exit 0
-      fi
-    done
+    startDeployment ${NAMESPACE} ${DEPLOY} ${CONTAINER}
+    if [ "$?" -eq 0 ]; then
+      continue
+    else
+      exit 0
+    fi
   done
 }
 

--- a/update.sh
+++ b/update.sh
@@ -6,7 +6,6 @@ USER=""
 NAMESPACE=""
 CLUSTER=""
 DEPLOYMENTS=""
-CONTAINERS=""
 SERVER_URL=""
 
 # set globals
@@ -113,31 +112,18 @@ pollDeploymentRollout(){
   done
 }
 
-startDeployment(){
-  local NAMESPACE=$1; shift
-  local DEPLOY=$1; shift
-  local CONTAINER=$1
-
-  kubectl -n ${NAMESPACE} set image deployment/${DEPLOY} \
-    *="${PLUGIN_REPO}:${PLUGIN_TAG}" --record
-  pollDeploymentRollout ${NAMESPACE} ${DEPLOY}
-  if [ "$?" -eq 0 ]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
 startDeployments(){
   local CLUSTER=$1; shift
   local NAMESPACE=$1
 
   IFS=',' read -r -a DEPLOYMENTS <<< "${PLUGIN_DEPLOYMENT}"
-  IFS=',' read -r -a CONTAINERS <<< "${PLUGIN_CONTAINER}"
 
   for DEPLOY in ${DEPLOYMENTS[@]}; do
     echo "[INFO] Deploying ${DEPLOY} to ${CLUSTER} ${NAMESPACE}"
-    startDeployment ${NAMESPACE} ${DEPLOY} ${CONTAINER}
+    kubectl -n ${NAMESPACE} set image deployment/${DEPLOY} \
+      *="${PLUGIN_REPO}:${PLUGIN_TAG}" --record
+    pollDeploymentRollout ${NAMESPACE} ${DEPLOY}
+
     if [ "$?" -eq 0 ]; then
       continue
     else


### PR DESCRIPTION
fixes multi-container deployments by using `kubectl set image deployment/<name> *=<image>`

Breaking change in `razorpay/drone-kubernetes` plugin usage.
`container:` block has to be omitted.