### PR TITLE
[clean_cluster_name] Clean clustername.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
         - PLUGIN_TAG=latest 
         - PLUGIN_REPO=octocat/hello-world 
         - SERVER_URL_KLUSTERAPI=https://kluster-api.k8s.razorpay.com.:443
-        - SERVER_CERT_STAGE=XXXX
-        - CLIENT_CERT_STAGE=XXXX
-        - CLIENT_KEY_STAGE=XXXX
+        - SERVER_CERT_KLUSTERAPI=XXXX
+        - CLIENT_CERT_KLUSTERAPI=XXXX
+        - CLIENT_KEY_KLUSTERAPI=XXXX
         - DRONE_COMMIT_SHA=d8dbe4d94f15fe89232e0402c6e8a0ddf21af3ab 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,11 +8,11 @@ services:
         - PLUGIN_DAEMONSET=api-web 
         - PLUGIN_USER=razorpay 
         - PLUGIN_NAMESPACE=default 
-        - PLUGIN_CLUSTER=stage 
+        - PLUGIN_CLUSTER=kluster-api
         - PLUGIN_AUTH_MODE=client-cert 
         - PLUGIN_TAG=latest 
         - PLUGIN_REPO=octocat/hello-world 
-        - SERVER_URL_STAGE=https://kube-stage.k8s.razorpay.com.:443
+        - SERVER_URL_KLUSTERAPI=https://kluster-api.k8s.razorpay.com.:443
         - SERVER_CERT_STAGE=XXXX
         - CLIENT_CERT_STAGE=XXXX
         - CLIENT_KEY_STAGE=XXXX

--- a/scripts/params.sh
+++ b/scripts/params.sh
@@ -21,6 +21,7 @@ setCluster(){
   if [ ! -z ${PLUGIN_CLUSTER} ]; then
     # convert cluster name to ucase and assign
     CLUSTER=${PLUGIN_CLUSTER^^}
+    CLUSTER=${CLUSTER//-}
   else
     echo "[ERROR] Required pipeline parameter: cluster not provided"
     exit 1


### PR DESCRIPTION
- The new prod api cluster contains `-` in the name.
- Bash variable substitution breaks in this case.
- Cleaning the name to remove `-`.